### PR TITLE
fix: remove ambient type declaration for virtual imports using `/@vite...` syntax

### DIFF
--- a/client.d.ts
+++ b/client.d.ts
@@ -5,9 +5,3 @@ declare module 'virtual:vite-icons/*' {
   const component: FunctionalComponent<SVGAttributes>
   export default component
 }
-
-declare module '/@vite-icons/*' {
-  import { FunctionalComponent, SVGAttributes } from 'vue'
-  const component: FunctionalComponent<SVGAttributes>
-  export default component
-}


### PR DESCRIPTION
The module declaration for the legacy virtual file imports (`declare module '/@vite-icons/*' {`) was causing Typescript to throw errors in some circumstances.

As it seems vite has now settled on the `virtual:...` convention instead, this declaration would only be for backwards compatibility, so I don't think it's necessary.

Removing this declaration resolves #25.